### PR TITLE
fix(gen-full): Avoid infinite loop when converting table/TOC to Markdown

### DIFF
--- a/src/cli/actions/gen.js
+++ b/src/cli/actions/gen.js
@@ -268,10 +268,19 @@ async function genFull(sitemapUrl) {
     emDelimiter: '*',
     hr: '---',
   });
+  // Configure Turndown for table content
+  const turndownServiceForTable = new TurndownService({
+    codeBlockStyle: 'fenced',
+    headingStyle: 'atx',
+    bulletListMarker: '-',
+    emDelimiter: '*',
+    hr: '---',
+  });
+  // add rule for table content
   turndownService.addRule('table', {
     filter: 'table',
     replacement: function(content, node) {
-      return '\n' + turndownService.turndown(node.outerHTML) + '\n';
+      return '\n' + turndownServiceForTable.turndown(node.outerHTML) + '\n';
     }
   });
   let output = '';


### PR DESCRIPTION
The existing turndown rule for 'table' elements caused a "Maximum call stack size exceeded" error due to recursive processing, particularly on pages with a Table of Contents (TOC).

This fix isolates the table conversion logic by using a dedicated turndown instance, preventing the infinite recursion caused by rule conflicts.